### PR TITLE
PLAT:51653: replace browser.pause() in UI tests

### DIFF
--- a/test/moonstone/ActivityPanels/ActivityPanels-specs.js
+++ b/test/moonstone/ActivityPanels/ActivityPanels-specs.js
@@ -1,127 +1,128 @@
 let Page = require('./ActivityPanelsPage');
 
 describe('ActivityPanels', function () {
-	it('should load first panel.', function () {
+	beforeEach(function () {
 		Page.open();
+	});
+
+	it('should load first panel.', function () {
+		Page.waitTransitionEnd();
 		expect(Page.panelTitle).to.equal('FIRST');
 	});
 
 	it('should have breadcrumb on second panel', function () {
-		Page.open();
+		Page.waitTransitionEnd();
 		Page.button1.click();
-		browser.pause(1000);
+		Page.waitTransitionEnd();
 
 		expect(Page.breadcrumbHeader.getText()).to.include('01');
 	});
 
 	describe('Transition', function () {
 		it('should move from first panel to the second', function () {
-			Page.open();
+			Page.waitTransitionEnd();
 			Page.button1.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 
 			expect(Page.panelTitle).to.equal('SECOND');
 		});
 
 		it('should navigate to DEFAULT ELEMENT', function () {
-			Page.open();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.item1.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.item5.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.button4.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.item2.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 
 			expect(Page.panelTitle).to.equal('DEFAULT ELEMENT');
 		});
 
 		it('should navigate back to the First panel from clicking on breadcrumb', function () {
-			Page.open();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.item1.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.item5.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.button4.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.item2.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.breadcrumbHeader.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.breadcrumbHeader.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.breadcrumbHeader.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.breadcrumbHeader.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 
 			expect(Page.panelTitle).to.equal('FIRST');
 		});
 
 		it('should navigate back to the Third panel from clicking on breadcrumb', function () {
-			Page.open();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.item1.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.item5.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.breadcrumbHeader.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.item8.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.button4.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			Page.breadcrumbHeader.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 
 			expect(Page.panelTitle).to.equal('THIRD');
 		});
 
 		it('should move from first panel to the third', function () {
-			Page.open();
+			Page.waitTransitionEnd();
 			Page.button1.moveToObject();
 			Page.spotlightSelect();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			expect(Page.panelTitle).to.equal('SECOND');
 			Page.item8.moveToObject();
 			Page.spotlightSelect();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 
 			expect(Page.panelTitle).to.equal('THIRD');
 		});
 
 		it('should move to first panel from the third', function () {
-			Page.open();
+			Page.waitTransitionEnd();
 			Page.button1.moveToObject();
 			Page.spotlightSelect();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			expect(Page.panelTitle).to.equal('SECOND');
 			Page.item8.moveToObject();
 			Page.spotlightSelect();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			expect(Page.panelTitle).to.equal('THIRD');
 			Page.breadcrumbHeader.moveToObject();
 			Page.spotlightSelect();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			expect(Page.panelTitle).to.equal('SECOND');
 			Page.item8.moveToObject();
 			Page.breadcrumbHeader.moveToObject();
 			Page.spotlightSelect();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 
 			expect(Page.panelTitle).to.equal('FIRST');
 		});
 
 		it('should transition back to First panel with back key', function () {
-			Page.open();
+			Page.waitTransitionEnd();
 			Page.button1.click();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 			expect(Page.panelTitle).to.equal('SECOND');
 			Page.backKey();
-			browser.pause(1000);
+			Page.waitTransitionEnd();
 
 			expect(Page.panelTitle).to.equal('FIRST');
 		});
@@ -129,28 +130,28 @@ describe('ActivityPanels', function () {
 
 	describe('Spotlight', function () {
 		it('should spot close button on render', function () {
-			Page.open();
+			Page.waitTransitionEnd();
 			expect(Page.closeButton.hasFocus()).to.be.true();
 		});
 
 		describe('pointer', function () {
 			it('should spot second item on second panel', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.item2.click();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				Page.backKey();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.item2.hasFocus()).to.be.true();
 			});
 
 			it('should spot second item on second panel after moving pointer', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.item2.click();
-				browser.pause(1000);
-				Page.item8.moveToObject()
+				Page.waitTransitionEnd();
+				Page.item8.moveToObject();
 				Page.backKey();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.item2.hasFocus()).to.be.true();
 			});
@@ -159,87 +160,88 @@ describe('ActivityPanels', function () {
 
 		describe('5way', function () {
 			it('should spot first item on second panel', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.spotlightDown();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.item5.hasFocus()).to.be.true();
 			});
 
 
 			it('should spot second item on first panel when using back key', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.backKey();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.item2.hasFocus()).to.be.true();
 			});
 
 			it('should spot button 4 in Third panel', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				// wait for page transition
+				Page.waitTransitionEnd();
+				// wait for Spotlight to focus
+				browser.pause(500);
 				expect(Page.button3.hasFocus()).to.be.true();
 				Page.spotlightRight();
 				expect(Page.button4.hasFocus()).to.be.true();
 				Page.spotlightDown();
 				expect(Page.breadcrumb.hasFocus()).to.be.true();
-				browser.pause(1000);
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.button4.hasFocus()).to.be.true();
 			});
 
 			it('should spot button 1 on First panel on Back key', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.spotlightDown();
 				Page.spotlightLeft();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.button3.hasFocus()).to.be.true();
 				Page.backKey();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.backKey();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.button1.hasFocus()).to.be.true();
 			});
 
 			it('should spot eighth item on second panel', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.spotlightLeft();
 				expect(Page.breadcrumb.hasFocus()).to.be.true();
 				Page.spotlightRight();
 				expect(Page.item5.hasFocus()).to.be.true();
-				browser.pause(1000);
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightDown();
@@ -251,17 +253,17 @@ describe('ActivityPanels', function () {
 
 
 			it('should spot third item on first panel', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightDown();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.spotlightLeft();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.item3.hasFocus()).to.be.true();
 			});
@@ -269,88 +271,87 @@ describe('ActivityPanels', function () {
 
 		describe('5way and pointer', function () {
 			it('should not spot in None panel', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.button1.moveToObject();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.panelTitle).to.equal('SECOND');
 				Page.item8.moveToObject();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.button3.hasFocus()).to.be.true();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.body.hasFocus()).to.be.true();
 
 			});
 
 			it('should spot default item in Default panel', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.button1.moveToObject();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.panelTitle).to.equal('SECOND');
 				Page.item8.moveToObject();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.panelTitle).to.equal('THIRD');
 				Page.button4.moveToObject();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.panelTitle).to.equal('NONE');
 				Page.button2.moveToObject();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.item5.hasFocus()).to.be.true();
 			});
 
 			it('should re-spot in Default panel', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.button1.moveToObject();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.item8.moveToObject();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.button3.hasFocus()).to.be.true();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.body.hasFocus()).to.be.true();
 				Page.spotlightDown();
 				expect(Page.item1.hasFocus()).to.be.true();
 				Page.button1.moveToObject();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.spotlightDown();
-				browser.pause(1000);
 				Page.backKey();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				Page.spotlightDown();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.item5.hasFocus()).to.be.true();
 
 			});
 
 			it('should spot item 3 on First panel on Back key', function () {
-				Page.open();
+				Page.waitTransitionEnd();
 				Page.item3.moveToObject();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.spotlightSelect();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.button3.hasFocus()).to.be.true();
 				Page.backKey();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 				expect(Page.item5.hasFocus()).to.be.true();
 				Page.backKey();
-				browser.pause(1000);
+				Page.waitTransitionEnd();
 
 				expect(Page.item3.hasFocus()).to.be.true();
 			});

--- a/test/moonstone/DatePicker/DatePicker-specs.js
+++ b/test/moonstone/DatePicker/DatePicker-specs.js
@@ -356,6 +356,7 @@ describe('DatePicker', function () {
 			describe('pointer', function () {
 				it('should not open when clicked', function () {
 					datePicker.title.click();
+					// it should never open, but wait and then check to be sure
 					browser.pause(500);
 					expectClosed(datePicker);
 				});

--- a/test/moonstone/TimePicker/TimePicker-specs.js
+++ b/test/moonstone/TimePicker/TimePicker-specs.js
@@ -373,6 +373,7 @@ describe('TimePicker', function () {
 			describe('pointer', function () {
 				it('should not open when clicked', function () {
 					timePicker.title.click();
+					// it should never open, but wait and then check to be sure
 					browser.pause(500);
 					expectClosed(timePicker);
 				});


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This removes some calls to `browser.pause()` that were in place to wait for transition events to occur and replaces them with a method that actually looks for `ontransitionend` events in `Page.waitTransitionEnd`.


### Links
[//]: # (Related issues, references)
PLAT-51653

Enact-DCO-1.0-Signed-off-by: Dave Freeman dave.freeman@lge.com