### PR TITLE
ENYO-5886: Enact-ui-tests: ExpandableInput test fails in "should not stop 5-way down when closed"

### DIFF
--- a/test/moonstone/ExpandableInput/ExpandableInput-specs.js
+++ b/test/moonstone/ExpandableInput/ExpandableInput-specs.js
@@ -567,6 +567,8 @@ describe('ExpandableInput', function () {
 
 		describe('general 5-way navigation', function () {
 			it('should not stop 5-way down when closed', function () {
+				// FIXME: Necessary to ensure 5-way mode and that focus is in expected location for test
+				// Additional follow up required to sort out why.
 				Page.components.default.focus();
 				Page.spotlightDown();
 				expect(Page.components.defaultValue.title.hasFocus()).to.be.true();


### PR DESCRIPTION
Force focus to first `ExpandableInput` before spotting the next one.