### PR TITLE
PLAT-99378: Update iLibWebpackPlugin to support ui/screenshot test structure

### DIFF
--- a/build-apps.js
+++ b/build-apps.js
@@ -1,12 +1,12 @@
 const path = require('path');
+const fs = require('fs-extra');
 const externals = require('@enact/dev-utils/mixins/externals');
 const framework = require('@enact/dev-utils/mixins/framework');
 const readdirp = require('readdirp');
 const webpack = require('webpack');
 const generator = require('./webpack.config.js');
 
-const ilib = path.join('node_modules', 'ilib');
-process.env.ILIB_BASE_PATH = ilib;
+process.env.ILIB_BASE_PATH = '/framework/node_modules/ilib';
 const enact = framework.apply(generator({
 	APPENTRY: 'framework',
 	APPOUTPUT: path.join('tests', 'ui', 'dist', 'framework')
@@ -32,6 +32,16 @@ function buildApps () {
 			if(!process.argv.includes('--skip-enact')) {
 				console.log('Packing Enact framework...');
 				return epack([enact]);
+			}
+		})
+		.then(() => {
+			if(!process.argv.includes('--skip-ilib')) {
+				console.log('Copying ilib locale data...');
+				fs.mkdirSync(path.join('tests', 'ui', 'dist', 'framework', 'ilib'))
+				return fs.copy(
+					path.join('node_modules', 'ilib', 'locale'),
+					path.join('tests', 'ui', 'dist', 'framework', 'ilib', 'locale')
+				)
 			}
 		})
 		.then(() => {

--- a/build-apps.js
+++ b/build-apps.js
@@ -6,7 +6,7 @@ const readdirp = require('readdirp');
 const webpack = require('webpack');
 const generator = require('./webpack.config.js');
 
-process.env.ILIB_BASE_PATH = '/framework/node_modules/ilib';
+process.env.ILIB_BASE_PATH = '/framework/ilib';
 const enact = framework.apply(generator({
 	APPENTRY: 'framework',
 	APPOUTPUT: path.join('tests', 'ui', 'dist', 'framework')

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "css-loader": "2.1.1",
     "dirty-chai": "2.0.1",
     "file-loader": "3.0.1",
+    "fs-extra": "8.1.0",
     "html-webpack-plugin": "4.0.0-alpha",
     "ilib": "^14.2.0",
     "less": "3.9.0",


### PR DESCRIPTION
* Sets iLib basepath top an absolute value to prevent copying for each individual ui test app.
* Separate iLib locale data copying into its own step in build process.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>