### PR TITLE
PLAT-98768: Replace less plugin with PostCSS plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "postcss-global-import": "1.0.6",
     "postcss-loader": "3.0.0",
     "postcss-remove-classes": "1.0.4",
+    "postcss-resolution-independence": "^1.0.0",
     "ramda": "0.26.1",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "readdirp": "2.2.1",
-    "resolution-independence": "1.0.0",
     "style-loader": "0.23.1",
     "thread-loader": "1.0.3",
     "wdio": "^3.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const flexbugfixes = require('postcss-flexbugs-fixes');
 const globalImport = require('postcss-global-import');
-const LessPluginRi = require('resolution-independence');
 const {DefinePlugin, EnvironmentPlugin} = require('webpack');
 const {optionParser: app, GracefulFsPlugin, ILibPlugin} = require('@enact/dev-utils');
 
@@ -194,7 +193,8 @@ module.exports = function (env) {
 									// See https://github.com/philipwalton/flexbugs
 									flexbugfixes,
 									// Support @global-import syntax to import css in a global context.
-									globalImport
+									globalImport,
+									app.ri !== false && require('postcss-resolution-independence')(app.ri)
 								]
 							}
 						},
@@ -202,9 +202,7 @@ module.exports = function (env) {
 							loader: require.resolve('less-loader'),
 							options: {
 								modifyVars: Object.assign({}, app.accent),
-								sourceMap: true,
-								// If resolution independence options are specified, use the LESS plugin.
-								plugins: app.ri ? [new LessPluginRi(app.ri)] : []
+								sourceMap: true
 							}
 						}
 					]


### PR DESCRIPTION
Update the webpack config and dependencies to use the newer PostCSS Plugin

Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>