### PR TITLE
PLAT-100080 Allow overwriting existing ilib files

### DIFF
--- a/build-apps.js
+++ b/build-apps.js
@@ -37,10 +37,11 @@ function buildApps () {
 		.then(() => {
 			if(!process.argv.includes('--skip-ilib')) {
 				console.log('Copying ilib locale data...');
-				fs.mkdirSync(path.join('tests', 'ui', 'dist', 'framework', 'ilib'));
+				const ilibDir = path.join('tests', 'ui', 'dist', 'framework', 'ilib');
+				if (!fs.existsSync(ilibDir)) fs.mkdirSync(ilibDir);
 				return fs.copy(
 					path.join('node_modules', 'ilib', 'locale'),
-					path.join('tests', 'ui', 'dist', 'framework', 'ilib', 'locale'),
+					path.join(ilibDir, 'locale'),
 					{overwrite: true}
 				);
 			}

--- a/build-apps.js
+++ b/build-apps.js
@@ -37,11 +37,12 @@ function buildApps () {
 		.then(() => {
 			if(!process.argv.includes('--skip-ilib')) {
 				console.log('Copying ilib locale data...');
-				fs.mkdirSync(path.join('tests', 'ui', 'dist', 'framework', 'ilib'))
+				fs.mkdirSync(path.join('tests', 'ui', 'dist', 'framework', 'ilib'));
 				return fs.copy(
 					path.join('node_modules', 'ilib', 'locale'),
-					path.join('tests', 'ui', 'dist', 'framework', 'ilib', 'locale')
-				)
+					path.join('tests', 'ui', 'dist', 'framework', 'ilib', 'locale'),
+					{overwrite: true}
+				);
 			}
 		})
 		.then(() => {


### PR DESCRIPTION
If the ilib files existed in the `dist` directory, testing would abort during build.

This fix checks for the existence first before attempting to make the directory and then will overwrite existing files.