### PR TITLE
Shorten filenames for long text and arrays

### DIFF
--- a/screenshot/utils/confHelpers.js
+++ b/screenshot/utils/confHelpers.js
@@ -1,5 +1,7 @@
 const path = require('path'),
-	fs = require('fs');
+	fs = require('fs'),
+	os = require('os');
+
 const VisualRegressionCompare = require('wdio-visual-regression-service/compare');
 const buildApps = require('../../src/build-apps');
 const makeHeader = require('./headerTemplate');
@@ -13,7 +15,14 @@ const newScreenshotFilename = 'tests/screenshot/dist/newFiles.html',
 
 function getScreenshotName (basePath) {
 	return function (context) {
-		const testName = context.test.title;
+		let testName = context.test.title;
+		// Replace problematic filenames. Windows is much more restrictive.
+		if (os.platform === 'win32') {
+			testName = testName.replace(/[/\\:?*"|<>]/g, '_');
+		} else {
+			testName = testName.replace(/\//g, '_');
+		}
+
 		return path.join(basePath, `${testName}.png`);
 	};
 }

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -65,9 +65,9 @@ const stringifyProps = (props = {}) => {
 		.replace(/:/g, ' = ')
 		.replace(/,/g, ', ')
 		// TODO: check for complex children and remove
-		.replace('props = children = ', '')
-		.replace('props = ', '')
-		.replace('wrapper = ', '');
+		.replace(/props = children = /g, '')
+		.replace(/props = /g, '')
+		.replace(/wrapper = /g, '');
 
 	return formattedString.length === 0 ? 'default' : formattedString;
 };

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -20,6 +20,13 @@ function replacer (key, value) {
 		};
 	} else if (value === '') {
 		return '<empty>';
+	} else if (typeof value === 'string') {
+		if (value.length > 10) {
+			value = value.slice(0, 8) + '…';
+		}
+		// Replace problematic filenames.  With the exception of '/', all these are valid on OS X
+		// and Linux, but sniffing the OS here is problematic.
+		value = value.replace(/[/\\:?*"|<>]/, '_');
 	} else if (key === 'key' || key === 'ref') {
 		// eslint-disable-next-line no-undefined
 		return undefined;
@@ -27,6 +34,8 @@ function replacer (key, value) {
 		return 'default';
 	} else if (this[key] instanceof Date) {	// `this` is instance of object that contains key/value
 		return formatDate(this[key]);		// Need to do this because toJson called before replacer
+	} else if (value instanceof Array && value.length > 4) {
+		value = value.slice(0, 3).concat('…');
 	}
 	return value;
 }


### PR DESCRIPTION
This PR shortens strings and arrays.  It replaces the excess with an ellipsis.  This will mean that some old filenames won't match up anymore.  With this, we don't have to use substitutions to avoid long filenames.  The text limit is pretty short but this could be adjusted.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com