### PR TITLE
PLAT-101901: Hash and truncate screenshot file names

### DIFF
--- a/screenshot/utils/confHelpers.js
+++ b/screenshot/utils/confHelpers.js
@@ -1,4 +1,5 @@
-const path = require('path'),
+const crypto = require('crypto'),
+	path = require('path'),
 	fs = require('fs'),
 	os = require('os');
 
@@ -22,6 +23,9 @@ function getScreenshotName (basePath) {
 		} else {
 			testName = testName.replace(/\//g, '_');
 		}
+
+		// shorten the name with a little bit of leading context to help find the file manually if necessary
+		testName = testName.substring(0, 128) + '-' + crypto.createHash('md5').update(testName).digest('hex');
 
 		return path.join(basePath, `${testName}.png`);
 	};

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -39,7 +39,7 @@ function replacer (key, value) {
 		value = value.replace('tests/screenshot/images/', '');
 		// Picked 15 arbitrarily so icons 'notification' and 'notificationoff' won't clash.
 		if (value.length > 15) {
-			value = value.slice(0, 15) + '...';
+			value = value.slice(0, 13) + '...';
 		}
 	} else if (key === 'key' || key === 'ref') {
 		// eslint-disable-next-line no-undefined

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -37,9 +37,9 @@ function replacer (key, value) {
 		return '<empty>';
 	} else if (typeof value === 'string') {
 		value = value.replace('tests/screenshot/images/', '');
-		// Picked 13 arbitrarily so icons 'notification' and 'notificationoff' won't clash.
-		if (value.length > 13) {
-			value = value.slice(0, 13) + '...';
+		// Picked 15 arbitrarily so icons 'notification' and 'notificationoff' won't clash.
+		if (value.length > 15) {
+			value = value.slice(0, 15) + '...';
 		}
 	} else if (key === 'key' || key === 'ref') {
 		// eslint-disable-next-line no-undefined

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -39,7 +39,7 @@ function replacer (key, value) {
 		value = value.replace('tests/screenshot/images/', '');
 		// Picked 13 arbitrarily so icons 'notification' and 'notificationoff' won't clash.
 		if (value.length > 13) {
-			value = value.slice(0, 13) + '…';
+			value = value.slice(0, 13) + '...';
 		}
 	} else if (key === 'key' || key === 'ref') {
 		// eslint-disable-next-line no-undefined

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -37,7 +37,7 @@ function replacer (key, value) {
 		return '<empty>';
 	} else if (typeof value === 'string') {
 		value = value.replace('tests/screenshot/images/', '');
-		// Picked 15 arbitrarily so icons 'notification' and 'notificationoff' won't clash.
+		// Picked 13 minimum arbitrarily so icons 'notification' and 'notificationoff' won't clash.
 		if (value.length > 15) {
 			value = value.slice(0, 13) + '...';
 		}


### PR DESCRIPTION
If a component has long enough props, it can produce a filename that is too long for the target filesystem. This PR truncates the name to 128 characters to give some context and then appends an md5 hash of the full file name to maintain uniqueness. It also changes the ellipsis character from #81 to three dots because the ellipsis was breaking the newFiles browser. This probably could have been fixed differently but the above hashing obviates the need to use only 1 character for the ellipsis.

Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>