### PR TITLE
Fix encoding for image src

### DIFF
--- a/screenshot/utils/redist/failedTests.js
+++ b/screenshot/utils/redist/failedTests.js
@@ -24,7 +24,8 @@
 		const title = document.querySelector('#title');
 		const preview = document.querySelector('.preview-image');
 		currentIndex = index;
-		image.src = results[index][`${type}Path`];
+		const urlParts = results[index][`${type}Path`].split('/');
+		image.src = [...urlParts.slice(0, -1), encodeURIComponent(urlParts.slice(-1)[0])].join('/');
 		title.innerText = `${results[index].title} (${currentIndex + 1} / ${count})`;
 		updateButtons(type);
 		if (results[index].title.indexOf('ar-SA') >= 0) {

--- a/screenshot/utils/redist/newFiles.js
+++ b/screenshot/utils/redist/newFiles.js
@@ -24,7 +24,8 @@
 		const title = document.querySelector('#title');
 		const preview = document.querySelector('.preview-image');
 		currentIndex = index;
-		image.src = results[index].path;
+		const urlParts = results[index].path.split('/');
+		image.src = [...urlParts.slice(0, -1), encodeURIComponent(urlParts.slice(-1)[0])].join('/');
 		title.innerText = `${results[index].title} (${currentIndex + 1} / ${count})`;
 		updateButtons();
 		if (results[index].title.indexOf('ar-SA') >= 0) {

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -38,8 +38,8 @@ function replacer (key, value) {
 	} else if (typeof value === 'string') {
 		value = value.replace('tests/screenshot/images/', '');
 		// Picked 13 minimum arbitrarily so icons 'notification' and 'notificationoff' won't clash.
-		if (value.length > 15) {
-			value = value.slice(0, 13) + '...';
+		if (value.length > 13) {
+			value = value.slice(0, 13) + '…';
 		}
 	} else if (key === 'key' || key === 'ref') {
 		// eslint-disable-next-line no-undefined


### PR DESCRIPTION
Some images weren't loading because the src URI wasn't encoded properly.  This, coincidentally, fixes the elipses issue as well, so I reverted that back.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com