### PR TITLE
Filter transition events that are not relevant

### DIFF
--- a/utils/Page.js
+++ b/utils/Page.js
@@ -118,14 +118,17 @@ class Page {
 	}
 
 	/* global window */
-	waitTransitionEnd (delay = 3000, msg = 'timed out waiting for transitionend', callback) {
+	waitTransitionEnd (delay = 3000, msg = 'timed out waiting for transitionend', callback, ignore = ['opacity', 'filter']) {
 		browser.execute(
-			function () {
-				window.ontransitionend = function () {
-					window.__transition = true;
+			function (ignore) {
+				window.ontransitionend = function (evt) {
+					if (!ignore || ignore.indexOf(evt.propertyName) === -1) {
+						window.__transition = true;
+					}
 				};
 				window.__transition = false;
-			}
+			},
+			ignore
 		);
 		if (callback) {
 			callback();

--- a/utils/Page.js
+++ b/utils/Page.js
@@ -120,6 +120,7 @@ class Page {
 	/* global window */
 	waitTransitionEnd (delay = 3000, msg = 'timed out waiting for transitionend', callback, ignore = ['opacity', 'filter']) {
 		browser.execute(
+			// eslint-disable-next-line no-shadow
 			function (ignore) {
 				window.ontransitionend = function (evt) {
 					if (!ignore || ignore.indexOf(evt.propertyName) === -1) {

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -28,7 +28,7 @@ function replacer (key, value) {
 		// If it's a string, it's a built-in type, output name and props
 		if (typeof type === 'string') {
 			// Must strip quotable characters before they get quoted again
-			const props = JSON.stringify(val, replacer).replace(/[{}"]/g, '')
+			const props = JSON.stringify(val, replacer).replace(/[{}"]/g, '');
 			return `<${type}>${props}</${type}>`;
 		} else {
 			return val;


### PR DESCRIPTION
New designs transition for spotlight focus.  This will filter out those transitions since we're generally not interested in them.  Sadly, we hardly use this feature anymore.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com