### PR TITLE
Put screenshots back in subdirectories

### DIFF
--- a/utils/runTest.js
+++ b/utils/runTest.js
@@ -38,7 +38,7 @@ const runTest = (props) => {
 							if (titlePattern && !testCase.title.match(titlePattern)) {
 								return;
 							}
-							it(`${component}/${testName}/${testCase.title}`, function () {
+							it(`${component}~/${testName}~/${testCase.title}`, function () {
 								const params = Page.serializeParams(Object.assign({
 									component,
 									testId,


### PR DESCRIPTION
An earlier attempt to fix filenames so they didn't have invalid characters in them caused intended directories to disappear.  This puts screenshots back into subdirectories and applies Windows-safe transforms to all the filenames so that Windows users can view files from the automation server (I'm looking at you, Jason and Jeremy).

A side effect of the problem was directory names were counting as part of the filename length, so filenames were truncated very short, not showing as many of the props as they could.

After this merge, all reference screenshots will need to be retaken since they filenames will be different.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com