### PR TITLE
PLAT-110982: Support ui-test on TV

### DIFF
--- a/screenshot/wdio.tv.conf.js
+++ b/screenshot/wdio.tv.conf.js
@@ -25,7 +25,7 @@ exports.config = Object.assign(
 			maxInstances: 1,
 			//
 			browserName: 'chrome',
-			chromeOptions: {
+			'goog:chromeOptions': {
 				debuggerAddress: `${process.env.TV_IP}:9998`
 			}
 		}],

--- a/ui/wdio.tv.conf.js
+++ b/ui/wdio.tv.conf.js
@@ -9,15 +9,12 @@ exports.config = Object.assign(
 			maxInstances: 1,
 
 			browserName: 'chrome',
-
 			'goog:chromeOptions': {
 				debuggerAddress: `${process.env.TV_IP}:9998`
 			}
 		}],
 
 		baseUrl: `http://${ipAddress()}:4567`,
-
-		services: ['sauce', 'selenium-standalone', 'static-server'],
 
 		before: function () {
 			if (config.before) config.before();

--- a/ui/wdio.tv.conf.js
+++ b/ui/wdio.tv.conf.js
@@ -1,9 +1,24 @@
+const ipAddress = require('../utils/ipAddress.js');
 const {config} = require('./wdio.conf.js');
 
 exports.config = Object.assign(
 	{},
 	config,
 	{
+		capabilities: [{
+			maxInstances: 1,
+
+			browserName: 'chrome',
+
+			'goog:chromeOptions': {
+				debuggerAddress: `${process.env.TV_IP}:9998`
+			}
+		}],
+
+		baseUrl: `http://${ipAddress()}:4567`,
+
+		services: ['sauce', 'selenium-standalone', 'static-server'],
+
 		before: function () {
 			if (config.before) config.before();
 			browser._options = {remote: true};


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>


ui-test is not currently performed on the TV board.

There was a missed part in the wdio.tv.config.js file at https://github.com/enactjs/ui-test-utils/pull/77.

I revive that missed part so that the ui-test could be performed on the TV.
