### PR TITLE
Force specific chromedriver

### DIFF
--- a/config/wdio.conf.js
+++ b/config/wdio.conf.js
@@ -132,7 +132,6 @@ module.exports.configure = (options) => {
 			// commands. Instead, they hook themselves up into the test process.
 			services: [
 				['selenium-standalone', {
-					skipSeleniumInstall: offline,
 					args: {
 						drivers : {
 							chrome : {

--- a/config/wdio.conf.js
+++ b/config/wdio.conf.js
@@ -131,7 +131,26 @@ module.exports.configure = (options) => {
 			// your test setup with almost no effort. Unlike plugins, they don't add new
 			// commands. Instead, they hook themselves up into the test process.
 			services: [
-				['selenium-standalone'],
+				['selenium-standalone', {
+					skipSeleniumInstall: offline,
+					args: {
+						drivers : {
+							chrome : {
+								version : '2.44',
+								arch    : process.arch
+							}
+						}
+					},
+					installArgs: {
+						drivers : {
+							chrome : {
+								version : '2.44',
+								arch    : process.arch,
+								baseURL : 'https://chromedriver.storage.googleapis.com'
+							}
+						}
+					}
+				}],
 				['static-server', {
 					folders: [
 						{ mount: '/', path: './tests/' + base + '/dist' }


### PR DESCRIPTION
This prevents the default selenium-standalone from attempting to use Chrome 83 allows us to resume Chrome 79 usage.

Cherrypicked from https://github.com/enactjs/ui-test-utils/pull/93

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>