### PR TITLE
PLAT-115838: i18n ui tests fail with ui-test-utils 0.5.0

### DIFF
--- a/src/build-apps.js
+++ b/src/build-apps.js
@@ -7,6 +7,7 @@ const readdirp = require('readdirp');
 
 const env = {
 	ILIB_BASE_PATH: '/framework/ilib',
+	ILIB_ASSET_CREATE: 'false',
 	SIMPLE_CSS_IDENT: 'true',
 	BROWSERSLIST: 'Chrome 79'
 };
@@ -107,6 +108,7 @@ function epack ({file, opts}) {
 		env: {
 			...process.env,
 			...env,
+			ILIB_CONTEXT: path.dirname(file.fullPath),
 			ENACT_ALIAS: JSON.stringify({UI_TEST_APP_ENTRY: file.fullPath}),
 			PUBLIC_URL: '/' + path.basename(file.fullPath, '.js')
 		},


### PR DESCRIPTION
* Ensure no ilibmanifest.json files are incidentally generated during ui test building.
* Target test view directories for iLib context to transfer/handle any test-based iLib resbundles.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>