### PR TITLE
PLAT-116194 Remove app name from imported images

### DIFF
--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -36,7 +36,8 @@ function replacer (key, value) {
 	} else if (value === '') {
 		return '<empty>';
 	} else if (typeof value === 'string') {
-		value = value.replace('tests/screenshot/images/', '');
+		// Automatically shorten filenames from imported images
+		value = value.replace(/.*tests\/screenshot\/images\//, '');
 		// Picked 13 minimum arbitrarily so icons 'notification' and 'notificationoff' won't clash.
 		if (value.length > 13) {
 			value = value.slice(0, 13) + '…';


### PR DESCRIPTION
With the new build the imported image filenames varied slightly from before.  This will trim off the full path, making the image names more useful.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com