### PR TITLE
Add excpetion catcher

### DIFF
--- a/screenshot/errorHandler.js
+++ b/screenshot/errorHandler.js
@@ -1,0 +1,6 @@
+// A little utility to catch errors executing the test generation routines
+
+window.addEventListener('error', errorMsg => {
+	window.__TEST_DATA = 'Error occurred: ' + errorMsg.message;
+	return false;
+}, {capture: true});

--- a/screenshot/index.js
+++ b/screenshot/index.js
@@ -1,3 +1,4 @@
+import './errorHandler';
 import React from 'react';
 import {render} from 'react-dom';
 import App, {testMetadata} from 'UI_TEST_APP_ENTRY';

--- a/utils/runTest.js
+++ b/utils/runTest.js
@@ -20,6 +20,10 @@ const runTest = ({concurrency, Page, skin, testName, ...rest}) => {
 				return window.__TEST_DATA; // eslint-disable-line no-undef
 			});
 
+			if (typeof testCases === 'string') {
+				throw new Error(`Test data failed to load: ${testCases}.\n\nLoad page in a browser to view the error.`)
+			}
+
 			expect(testCases).to.be.an('object', 'Test data failed to load');
 
 			describe(testName, function () {


### PR DESCRIPTION
This will give better diagnostics information if an error in a test case prevents the test cases from being enumerated.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com