### PR TITLE
PLAT-126474: Update dependent modules for ui-test-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "access": "public"
   },
   "dependencies": {
-    "@wdio/cli": "^6.1.17",
-    "@wdio/dot-reporter": "^6.1.14",
-    "@wdio/local-runner": "^6.1.17",
-    "@wdio/mocha-framework": "^6.1.17",
-    "@wdio/selenium-standalone-service": "^6.1.14",
-    "@wdio/spec-reporter": "^6.1.14",
-    "@wdio/static-server-service": "^6.1.14",
-    "@wdio/sync": "^6.1.14",
+    "@wdio/cli": "^6.10.3",
+    "@wdio/dot-reporter": "^6.10.3",
+    "@wdio/local-runner": "^6.10.3",
+    "@wdio/mocha-framework": "^6.10.3",
+    "@wdio/selenium-standalone-service": "^6.10.3",
+    "@wdio/spec-reporter": "^6.10.3",
+    "@wdio/static-server-service": "^6.10.3",
+    "@wdio/sync": "^6.10.3",
     "chai": "4.2.0",
     "chalk": "^4.1.0",
     "cross-spawn": "^7.0.3",
@@ -36,7 +36,7 @@
     "readdirp": "^3.4.0",
     "wdio-docker-service": "^2.3.0",
     "wdio-novus-visual-regression-service": "^1.2.0",
-    "webdriverio": "^6.1.7"
+    "webdriverio": "^6.10.3"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
@@ -50,6 +50,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.8",
-    "react": "^16.8.6"
+    "react": "^17.0.1"
   }
 }


### PR DESCRIPTION
Update dependencies for React 17.
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>
