### PR TITLE
WRN-792: Use correct chrome driver according to the chrome version.

### DIFF
--- a/config/wdio.conf.js
+++ b/config/wdio.conf.js
@@ -1,4 +1,6 @@
 const parseArgs = require('minimist');
+const execSync = require('child_process').execSync;
+const got = require('got');
 
 const args = parseArgs(process.argv);
 
@@ -13,6 +15,24 @@ module.exports.configure = (options) => {
 	delete opts.base;
 	delete opts.before;
 	delete opts.services;
+
+	let chromeDriverVersion = 'latest';	// TODO 보드에서 잘되는지 보기
+
+	if (process.platform !== "win32") {
+		let chromeVersionMajorNumber;
+
+		try {
+			const chromeVersion = /Chrome (\d+)/.exec(execSync('google-chrome -version'));
+			chromeVersionMajorNumber = (chromeVersion && chromeVersion[1]);
+		} catch (error) {
+			console.log('ERROR: Cannnot find Chrome version');
+		}
+
+		chromeDriverVersion = execSync('curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE' + (chromeVersionMajorNumber ? ('_' + chromeVersionMajorNumber) : ''));
+		console.log('Chrome Driver Version : ' + chromeDriverVersion);
+	};
+
+	// TODO: get chrome version on Windows
 
 	return Object.assign(
 		opts,
@@ -138,7 +158,8 @@ module.exports.configure = (options) => {
 					args: {
 						drivers : {
 							chrome : {
-								version : '2.44',
+								version : chromeDriverVersion,
+								// version : 'latest',
 								arch    : process.arch
 							}
 						}
@@ -146,7 +167,8 @@ module.exports.configure = (options) => {
 					installArgs: {
 						drivers : {
 							chrome : {
-								version : '2.44',
+								version : chromeDriverVersion,
+								// version : 'latest',
 								arch    : process.arch,
 								baseURL : 'https://chromedriver.storage.googleapis.com'
 							}

--- a/config/wdio.conf.js
+++ b/config/wdio.conf.js
@@ -16,21 +16,22 @@ module.exports.configure = (options) => {
 	delete opts.before;
 	delete opts.services;
 
-	let chromeDriverVersion = 'latest';	// TODO 보드에서 잘되는지 보기
+	let chromeVersionMajorNumber;
 
-	if (process.platform !== "win32") {
-		let chromeVersionMajorNumber;
-
+	if (process.platform === 'win32') {
+		const chromeVersion = /\d+/.exec(execSync('wmic datafile where "name=\'C:\\\\Program Files (x86)\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe\'" get Version /value').toString());
+		chromeVersionMajorNumber = (chromeVersion && chromeVersion[0]);
+	} else {
 		try {
 			const chromeVersion = /Chrome (\d+)/.exec(execSync('google-chrome -version'));
 			chromeVersionMajorNumber = (chromeVersion && chromeVersion[1]);
 		} catch (error) {
 			console.log('ERROR: Cannnot find Chrome version');
 		}
-
-		chromeDriverVersion = execSync('curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE' + (chromeVersionMajorNumber ? ('_' + chromeVersionMajorNumber) : ''));
-		console.log('Chrome Driver Version : ' + chromeDriverVersion);
 	};
+
+	const chromeDriverVersion = execSync('curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE' + (chromeVersionMajorNumber ? ('_' + chromeVersionMajorNumber) : ''));
+	console.log('Chrome Driver Version : ' + chromeDriverVersion);
 
 	// TODO: get chrome version on Windows
 

--- a/screenshot/wdio.tv.conf.js
+++ b/screenshot/wdio.tv.conf.js
@@ -25,6 +25,7 @@ exports.config = Object.assign(
 			//
 			browserName: 'chrome',
 			'goog:chromeOptions': {
+				w3c: false,
 				debuggerAddress: `${process.env.TV_IP}:9998`
 			}
 		}],

--- a/ui/wdio.tv.conf.js
+++ b/ui/wdio.tv.conf.js
@@ -10,6 +10,7 @@ exports.config = Object.assign(
 
 			browserName: 'chrome',
 			'goog:chromeOptions': {
+				w3c: false,
 				debuggerAddress: `${process.env.TV_IP}:9998`
 			}
 		}],


### PR DESCRIPTION
The 2.44 chrome driver we are using supports Chrome v69-71. However, it was compatible with the latest browsers without any problems.

Recently, There was a report that the current ui-test-utils does not work in the Chrome 89 environment.
2.44 is a very old version and it cannot work in the latest browser suddenly in the future.

So In this PR, I use correct chrome driver according to the actual chrome version.
