### PR TITLE
WRN-793: Support WebOS TV screenshot test

### DIFF
--- a/screenshot/wdio.tv.conf.js
+++ b/screenshot/wdio.tv.conf.js
@@ -1,10 +1,19 @@
 const ipAddress = require('../utils/ipAddress.js');
 const {config} = require('./wdio.conf.js');
 
+const services = config.services.map(service => {
+	if (service[0] === 'novus-visual-regression') {
+		delete service[1].viewports;
+	}
+	return service;
+});
+
 exports.config = Object.assign(
 	{},
 	config,
 	{
+		services,
+
 		// ============
 		// Capabilities
 		// ============
@@ -44,6 +53,9 @@ exports.config = Object.assign(
 			if (config.before) {
 				config.before();
 			}
+
+			browser._options = {remote: true};
+
 			// Have to stub out these methods to prevent exceptions when running against
 			// remote chrome session
 			browser.setViewportSize = () => Promise.resolve({height: 1080, width: 1920});

--- a/ui/wdio.tv.conf.js
+++ b/ui/wdio.tv.conf.js
@@ -17,7 +17,10 @@ exports.config = Object.assign(
 		baseUrl: `http://${ipAddress()}:4567`,
 
 		before: function () {
-			if (config.before) config.before();
+			if (config.before) {
+				config.before();
+			}
+
 			browser._options = {remote: true};
 		}
 	}


### PR DESCRIPTION
* Issue Resolved : 
We cannot perform the screenshot test on webOS board due to below error.
```
Error: unknown error: unhandled inspector error: {"code":-32601,"message":"'Browser.getWindowForTarget' wasn't found"}
  (Session info: content shell=)
```


* Resolution : 
1. We need `remote: true` option like ui-test tv config
2. We should not change viewport size on board env. The option is supported for desktop only. (https://webdriver.io/docs/wdio-novus-visual-regression-service/#options)
Please refer https://github.com/enactjs/ui-test-utils/blob/master/screenshot/wdio.conf.js#L12.
and https://github.com/enactjs/ui-test-utils/blob/master/screenshot/wdio.docker.conf.js#L5

Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)