### PR TITLE
WRN-18565: Updated chrome installation folder for Windows

### DIFF
--- a/config/wdio.conf.js
+++ b/config/wdio.conf.js
@@ -23,7 +23,7 @@ module.exports.configure = (options) => {
 			try {
 				if (process.platform === 'win32') {
 					// Windows
-					const chromeVersion = /\d+/.exec(execSync('wmic datafile where "name=\'C:\\\\Program Files (x86)\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe\'" get Version /value').toString());
+					const chromeVersion = /\d+/.exec(execSync('wmic datafile where "name=\'C:\\\\Program Files\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe\'" get Version /value').toString());
 					chromeVersionMajorNumber = (chromeVersion && chromeVersion[0]);
 				} else if (process.platform === 'darwin') {
 					// Mac


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [X] Documentation was verified or is not changed
* [X] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Google Chrome installation folder changed from Program files(x86) to Program Files.
If the local chrome version is not read, then ui-test-utils would download the latest release of chromedriver, which can be different than the local version of Chrome. In that case, the ui and ss tests would fail locally

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-18565

### Comments
Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)