### PR TITLE
WRN-12124: Remove deprecated babel-eslint module

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.16.3",
     "eslint": "^7.11.0",
-    "eslint-config-enact": "github:enactjs/eslint-config-enact#feature/WRN-12124",
+    "eslint-config-enact": "^3.0.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-enact": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "webdriverio": "^7.9.0"
   },
   "devDependencies": {
-    "babel-eslint": "^10.1.0",
+    "@babel/eslint-parser": "^7.16.3",
     "eslint": "^7.11.0",
-    "eslint-config-enact": "^3.0.0",
+    "eslint-config-enact": "github:enactjs/eslint-config-enact#feature/WRN-12124",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-enact": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "webdriverio": "^7.9.0"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.16.3",
     "eslint": "^7.11.0",
     "eslint-config-enact": "^3.0.0",
     "eslint-config-prettier": "^6.11.0",

--- a/ui/wdio.docker.conf.js
+++ b/ui/wdio.docker.conf.js
@@ -3,7 +3,7 @@ const {config} = require('./wdio.conf.js');
 
 // Remove selenium-standalone and replace with docker service
 const services = config.services
-	.filter(service => service !== 'selenium-standalone')
+	.filter(service => service[0] !== 'selenium-standalone')
 	.concat(['docker']);
 
 exports.config = Object.assign(


### PR DESCRIPTION
### Issue Resolved / Feature Added
`babel-eslint` has been deprecated

```
`babel-eslint` is now `@babel/eslint-parser`. This package will no longer receive updates.
```

### Resolution
Remove deprecated `babel-eslint` 

### Additional Considerations

### Links
WRN-12124

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)