### PR TITLE
WRO-11781: Fixed waitTransitionEnd util function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 
 * Fixed the first tests in the test suite fail randomly by adding missed `await` in `utils/Page`.
+* Fixed the util method `waitTransitionEnd` in `utils/Page` to correctly call `browser.waitUntil()` and to wait for the promise of `browser.execute()` to be resolved.
 
 ## [1.0.0] (June 8, 2022)
 

--- a/utils/Page.js
+++ b/utils/Page.js
@@ -142,7 +142,7 @@ class Page {
 		await browser.waitUntil(() => target.isExisting() && target.isFocused(), {timeout, timeoutMsg, interval});
 	}
 
-	async waitTransitionEnd (delay = 3000, msg = 'timed out waiting for transitionend', callback, ignore = ['opacity', 'filter']) {
+	async waitTransitionEnd (timeout = 3000, timeoutMsg = 'timed out waiting for transitionend', callback, ignore = ['opacity', 'filter']) {
 		await browser.execute(
 			// eslint-disable-next-line no-shadow
 			function (ignore) {
@@ -166,7 +166,7 @@ class Page {
 					}
 				);
 			},
-			{timeout: delay, timeoutMsg: msg}
+			{timeout, timeoutMsg}
 		);
 	}
 }

--- a/utils/Page.js
+++ b/utils/Page.js
@@ -159,15 +159,14 @@ class Page {
 			callback();
 		}
 		await browser.waitUntil(
-			function () {
-				return browser.execute(
+			async function () {
+				return await browser.execute(
 					function () {
 						return window.__transition;
 					}
 				);
 			},
-			delay,
-			msg
+			{timeout: delay, timeoutMsg: msg}
 		);
 	}
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- UI Tests which were calling waitTransitioEnd were failing randomly, but quite often, with the error `Error: waitUntil condition timed out after 10000ms`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- I added async-await to browser.execute(). It returns a promise and we need to wait for it to be resolved
- the method browser.waitUntil was not called correctly, the timeout and timeout message should have been put in an object, according to https://webdriver.io/docs/api/browser/waitUntil/ . I updated the call of the method accordingly


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Check the user story for ui-tests results

### Links
[//]: # (Related issues, references)
WRO-11781

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)