### PR TITLE
WRP-2585: Added pressSelectKey property for screenshot test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [unreleased]
+
+* Added a conditional action in `utils/runTest` before taking the screenshot, if the testsCase has a `pressSelectKey` property.
+
+
 ## [1.0.2] (December 22, 2022)
 
 * Fixed the util method `waitTransitionEnd` in `utils/Page` by adding `await` to the callback and async-await for the handler function of ontransitionend event.

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -99,8 +99,7 @@ const generateTestData = (component, componentTests) => {
 
 		const meta = {
 			pressSelectKey: testCase.pressSelectKey,
-			title,
-
+			title
 		};
 		metaData.push(meta);
 	});

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -98,8 +98,9 @@ const generateTestData = (component, componentTests) => {
 		}
 
 		const meta = {
+			pressSelectKey: testCase.pressSelectKey,
 			title,
-			pressSelectKey: testCase.pressSelectKey
+
 		};
 		metaData.push(meta);
 	});

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -92,12 +92,14 @@ const generateTestData = (component, componentTests) => {
 				props: testCase.props ? testCase.props : testCase.component.props,
 				wrapper: testCase.wrapper,
 				textSize: testCase.textSize,
-				skinVariants: testCase.skinVariants
+				skinVariants: testCase.skinVariants,
+				pressSelectKey: testCase.pressSelectKey
 			});
 		}
 
 		const meta = {
-			title
+			title,
+			pressSelectKey: testCase.pressSelectKey
 		};
 		metaData.push(meta);
 	});

--- a/utils/runTest.js
+++ b/utils/runTest.js
@@ -63,6 +63,11 @@ const runTest = ({concurrency, filter, Page, testName, ...rest}) => {
 
 								await Page.open(`?${params}`);
 
+								if (testCase.pressSelectKey) {
+									console.log("test");
+									await Page.spotlightSelect();
+								}
+
 								expect(await browser.checkScreen(screenshotFileName, {
 									disableCSSAnimation: true,
 									ignoreNothing: true,

--- a/utils/runTest.js
+++ b/utils/runTest.js
@@ -64,7 +64,6 @@ const runTest = ({concurrency, filter, Page, testName, ...rest}) => {
 								await Page.open(`?${params}`);
 
 								if (testCase.pressSelectKey) {
-									console.log("test");
 									await Page.spotlightSelect();
 								}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was no possibility to execute an action before taling the screenhot for a view

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added pressSelectKey property for screenshot test cases. If this property exists and is true, then a `await Page.spotlightSelect();` action is executed before `browser.checkScreen()`.
Added the pressSelectKey information in the screenshot filename in order to generate a different file when this flag is set.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-2585

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)