### PR TITLE
WRP-9221: Update .travis.yml to build with the current node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: focal
 language: node_js
 node_js:
-    - "18"
+    - node
 before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Need to revert what was built with node 18 because of an canvas module's error when running to the current node version.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update .travis.yml to build with the current node version again because node 19 support in canvas 2.10.2 library was provided

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-9221

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)