### PR TITLE
WRQ-27998: Updated so that driver path can be found in Chrome 114 or higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: focal
 language: node_js
 node_js:
-    - node
+    - "21"
 before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: focal
 language: node_js
 node_js:
-    - "21"
+    - node
 before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev

--- a/config/wdio.conf.js
+++ b/config/wdio.conf.js
@@ -33,7 +33,13 @@ module.exports.configure = (options) => {
 					const chromeVersion = /Chrome (\d+)/.exec(execSync('google-chrome -version'));
 					chromeVersionMajorNumber = (chromeVersion && chromeVersion[1]);
 				}
-				const chromeDriverVersion = execSync('curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE' + (chromeVersionMajorNumber ? ('_' + chromeVersionMajorNumber) : ''));
+				let chromeDriverVersion;
+
+				if (chromeVersionMajorNumber > 114) {
+					chromeDriverVersion = execSync('curl https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE' + (chromeVersionMajorNumber ? ('_' + chromeVersionMajorNumber) : ''));
+				} else {
+					chromeDriverVersion = execSync('curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE' + (chromeVersionMajorNumber ? ('_' + chromeVersionMajorNumber) : ''));
+				}
 
 				if (chromeDriverVersion.includes('Error') || !/\d+.\d+.\d+.\d+/.exec(chromeDriverVersion)) {
 					throw new Error();
@@ -183,7 +189,7 @@ module.exports.configure = (options) => {
 							chrome : {
 								version : process.env.CHROME_DRIVER,
 								arch    : process.arch,
-								baseURL : 'https://chromedriver.storage.googleapis.com'
+								baseURL : process.env.CHROME_DRIVER > 114 ? 'https://storage.googleapis.com' : 'https://chromedriver.storage.googleapis.com'
 							}
 						}
 					}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated testing and it is passed
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We created a server for Chrome version 120, and an issue occurred where Chrome driver 120 version was not found when building on a server where Chrome version 120 was applied

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We can set args in selenium-standalone service. Update the driver import path as it has changed since Chrome version 114
refer to : 
 - https://chromedriver.storage.googleapis.com/LATEST_RELEASE
 - https://developer.chrome.com/docs/chromedriver/downloads/version-selection


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-27998

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
