### PR TITLE
WRR-1039: Added `--no animation` option for screenshot test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [unreleased]
+
+* Added `--no-animation` option for screenshot test.
+
 ## [1.0.10] (October 31, 2024)
 
 * Updated dependencies.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,15 @@ For example, filtering for the component 'Input'.
 npm run test-ui -- --visible --spec /Input
 ```
 
+### Running without animation effects
+
+The `--no-animation` option is used to pack Enact without animation.
+You can use this option to test the apps without animation effects.
+
+```bash
+npm run test-ss -- --no-animation
+```
+
 ### Loading sample apps in a browser
 
  This requires that a server be running on port 3000. If you have globally installed the `serve`

--- a/src/build-apps.js
+++ b/src/build-apps.js
@@ -31,7 +31,8 @@ function buildApps (base) {
 						'--output',
 						path.join('tests', base, 'dist', 'framework'),
 						'--framework',
-						'--externals-polyfill'
+						'--externals-polyfill',
+						process.argv.includes('--no-animation') ? '--no-animation' : null
 					]
 				});
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In this PR https://github.com/enactjs/sandstone/pull/1769, I added conditions to turn off animation and shadow effects with cli `--no-animation` build option.
To verify effects are removed with that option, we need screenshot test for `--no-animaton`. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added `--no-animation` option for test.
`npm run test-ss -- --no-animation` will pack the app with no effects and run the screenshot test.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
`--no-animation` option can be used not only for sandstone screenshot test but also generally.
So I wrote that the option packs "enact" and runs "test" without effects in README.md file,
but conditions to turn of the effects are added in sandstone only for now.
Do we need to implement some features like sandstone in other theme libraries (ex. agate) or change the explanation to specify?

### Links
[//]: # (Related issues, references)
WRR-1039

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim ([jiye.kim@lge.com](mailto:jiye.kim@lge.com))