### PR TITLE
WRR-22655: fix for ss-tests on TV board and Fix for ui test screenshot saving error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [unreleased]
+
+* Fixed screenshot saving failure for ui-tests by adding `await` to `browser.saveScreenshot()`.
+
 ## [2.0.0-alpha.2] (March 7, 2025)
 
 * Updated `webdriverio` and related dependencies to version 9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [unreleased]
 
-* Fixed screenshot saving failure for ui-tests by adding `await` to `browser.saveScreenshot()`.
+* Fixed ui-tests errorShot saving failure by adding `await` to `browser.saveScreenshot()`.
+* Fixed ss-tests number of running instances on tv board by fixing maxInstances config property name.
 
 ## [2.0.0-alpha.2] (March 7, 2025)
 

--- a/config/wdio.conf.js
+++ b/config/wdio.conf.js
@@ -115,7 +115,7 @@ module.exports.configure = (options) => {
 				// maxInstances can get overwritten per capability. So if you have an in-house Selenium
 				// grid with only 5 firefox instances available you can make sure that not more than
 				// 5 instances get started at a time.
-				maxInstances,
+				'wdio:maxInstances': maxInstances,
 				//
 				browserName: 'chrome',
 				/* WebdriverIO v8.14 and above downloads and uses the latest Chrome version when running tests.

--- a/screenshot/wdio.tv.conf.js
+++ b/screenshot/wdio.tv.conf.js
@@ -30,7 +30,7 @@ exports.config = Object.assign(
 			// maxInstances can get overwritten per capability. So if you have an in-house Selenium
 			// grid with only 5 firefox instances available you can make sure that not more than
 			// 5 instances get started at a time.
-			maxInstances: 1,
+			'wdio:maxInstances': 1,
 			//
 			browserName: 'chrome',
 			/* WebdriverIO v8.14 and above downloads and uses the latest Chrome version when running tests.

--- a/ui/wdio.conf.js
+++ b/ui/wdio.conf.js
@@ -31,7 +31,7 @@ exports.config = configure({
 	 * @param {Number} result.duration duration of test
 	 * @param {Boolean} result.passed true if test has passed, otherwise false
 	 */
-	afterTest: function (testCase, _context, {duration, passed}) {
+	afterTest: async function (testCase, _context, {duration, passed}) {
 		if (duration > 2000) {
 			console.log(chalk.yellow(`Long running test case: ${testCase.title}: ${duration}ms`));
 		}
@@ -48,7 +48,7 @@ exports.config = configure({
 			fs.mkdirSync(this.screenshotPath, {recursive: true});	// May only work recursively on Node 10.12+
 		}
 		// save screenshot
-		browser.saveScreenshot(filePath);
+		await browser.saveScreenshot(filePath);
 		console.log('\n\tScreenshot location:', filePath, '\n');
 	},
 	afterSuite: function (_suite) {

--- a/ui/wdio.tv.conf.js
+++ b/ui/wdio.tv.conf.js
@@ -6,8 +6,11 @@ exports.config = Object.assign(
 	config,
 	{
 		capabilities: [{
-			maxInstances: 1,
-
+			// maxInstances can get overwritten per capability. So if you have an in-house Selenium
+			// grid with only 5 firefox instances available you can make sure that not more than
+			// 5 instances get started at a time.
+			'wdio:maxInstances': 1,
+			//
 			browserName: 'chrome',
 			/* WebdriverIO v8.14 and above downloads and uses the latest Chrome version when running tests.
 			We need to specify a browser version that match chromedriver version running in CI/CD environment to


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Error shots were not saved  correctly after an ui-test fail
Ss-tests on TV board are not compared with the correct reference and they fail.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `await` to `browser.saveScreenshot()`., according to wdio documentation https://webdriver.io/docs/api/element/saveScreenshot/ 

On TV board, only 1 instance should be run at one moment. I noticed that 5 instances were run in paralel and this caused incorrect screenshot comparison.
Replaced maxInstances with `wdio:maxInstances`. The config property name changed in wdio9. We missed this during the migration
wdio7: https://v7.webdriver.io/docs/options/#capabilities-1 
wdio9: https://webdriver.io/docs/capabilities/#wdiomaxinstances

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-22655

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)