### PR TITLE
NXT-7082: Updated major dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: jammy
 language: node_js
 node_js:
-    - 21
+    - 20
 before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [unreleased]
+
+* Updated dependencies versions to the latest.
+* Required Node.js version "^20.19.0 || ^22.0.0 || >=24.0.0"
+
 ## [4.0.1] (January 13, 2026)
 
 * Updated Chrome driver version to 132 for screenshot tests.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -21,7 +21,7 @@
         "expect-webdriverio": "^5.5.0",
         "fs-extra": "^11.3.2",
         "minimist": "^1.2.8",
-        "query-string": "^9.3.1",
+        "query-string": "^7.1.3",
         "ramda": "^0.32.0",
         "readdirp": "^5.0.0",
         "wdio-docker-service": "^3.2.1",
@@ -36,7 +36,7 @@
         "globals": "^17.0.0"
       },
       "engines": {
-        "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3200,12 +3200,12 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
-      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=0.10"
       }
     },
     "node_modules/deep-eql": {
@@ -10520,15 +10520,12 @@
       }
     },
     "node_modules/filter-obj": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
-      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -13128,17 +13125,18 @@
       "license": "MIT"
     },
     "node_modules/query-string": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.3.1.tgz",
-      "integrity": "sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
       "license": "MIT",
       "dependencies": {
-        "decode-uri-component": "^0.4.1",
-        "filter-obj": "^5.1.0",
-        "split-on-first": "^3.0.0"
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13896,15 +13894,12 @@
       "license": "CC0-1.0"
     },
     "node_modules/split-on-first": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
-      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/split2": {
@@ -13964,6 +13959,15 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -21,9 +21,9 @@
         "expect-webdriverio": "^5.5.0",
         "fs-extra": "^11.3.2",
         "minimist": "^1.2.8",
-        "query-string": "^7.1.3",
-        "ramda": "^0.31.3",
-        "readdirp": "^3.6.0",
+        "query-string": "^9.3.1",
+        "ramda": "^0.32.0",
+        "readdirp": "^5.0.0",
         "wdio-docker-service": "^3.2.1",
         "webdriverio": "^9.21.0"
       },
@@ -33,7 +33,7 @@
       "devDependencies": {
         "eslint": "^9.39.1",
         "eslint-config-enact": "^5.0.3",
-        "globals": "^16.5.0"
+        "globals": "^17.0.0"
       },
       "engines": {
         "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
@@ -3200,12 +3200,12 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=14.16"
       }
     },
     "node_modules/deep-eql": {
@@ -10520,12 +10520,15 @@
       }
     },
     "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/finalhandler": {
@@ -10873,9 +10876,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.0.0.tgz",
+      "integrity": "sha512-gv5BeD2EssA793rlFWVPMMCqefTlpusw6/2TbAVMy0FzcG8wKJn4O+NqJ4+XWmmwrayJgw5TzrmWjFgmz1XPqw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12324,6 +12327,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/mocha/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/mocha/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -13101,27 +13128,26 @@
       "license": "MIT"
     },
     "node_modules/query-string": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
-      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.3.1.tgz",
+      "integrity": "sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==",
       "license": "MIT",
       "dependencies": {
-        "decode-uri-component": "^0.2.2",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ramda": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.31.3.tgz",
-      "integrity": "sha512-xKADKRNnqmDdX59PPKLm3gGmk1ZgNnj3k7DryqWwkamp4TJ6B36DdpyKEQ0EoEYmH2R62bV4Q+S0ym2z8N2f3Q==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
+      "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -13373,27 +13399,16 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">= 20.19.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/recursive-readdir": {
@@ -13881,12 +13896,15 @@
       "license": "CC0-1.0"
     },
     "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/split2": {
@@ -13946,15 +13964,6 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
-      }
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Roy Sutton <roy.sutton@lge.com>",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
+    "node": "^20.19.0 || ^22.0.0 || >=24.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "expect-webdriverio": "^5.5.0",
     "fs-extra": "^11.3.2",
     "minimist": "^1.2.8",
-    "query-string": "^9.3.1",
+    "query-string": "^7.1.3",
     "ramda": "^0.32.0",
     "readdirp": "^5.0.0",
     "wdio-docker-service": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -41,16 +41,16 @@
     "expect-webdriverio": "^5.5.0",
     "fs-extra": "^11.3.2",
     "minimist": "^1.2.8",
-    "query-string": "^7.1.3",
-    "ramda": "^0.31.3",
-    "readdirp": "^3.6.0",
+    "query-string": "^9.3.1",
+    "ramda": "^0.32.0",
+    "readdirp": "^5.0.0",
     "wdio-docker-service": "^3.2.1",
     "webdriverio": "^9.21.0"
   },
   "devDependencies": {
     "eslint": "^9.39.1",
     "eslint-config-enact": "^5.0.3",
-    "globals": "^16.5.0"
+    "globals": "^17.0.0"
   },
   "overrides": {
     "cross-spawn": "$cross-spawn",

--- a/src/build-apps.js
+++ b/src/build-apps.js
@@ -10,7 +10,7 @@ const env = {
 	ILIB_BASE_PATH: '/framework/ilib',
 	ILIB_ASSET_CREATE: 'false',
 	SIMPLE_CSS_IDENT: 'true',
-	BROWSERSLIST: 'Chrome 79'
+	BROWSERSLIST: 'Chrome 132'
 };
 
 function findViews (base) {

--- a/src/build-apps.js
+++ b/src/build-apps.js
@@ -3,7 +3,7 @@ import path from 'path';
 let chalk;
 import spawn from 'cross-spawn';
 import fs from 'fs-extra';
-import readdirp from 'readdirp';
+import {readdirpPromise} from 'readdirp';
 import * as url from 'url';
 
 const env = {
@@ -14,7 +14,9 @@ const env = {
 };
 
 function findViews (base) {
-	return readdirp.promise(path.join('tests', base, 'apps'), {fileFilter: '*-View.js'});
+	return readdirpPromise(path.join('tests', base, 'apps'), {
+		fileFilter: (entry) => entry.basename.endsWith('-View.js')
+	});
 }
 
 // eslint-disable-next-line no-shadow

--- a/utils/Page.js
+++ b/utils/Page.js
@@ -12,7 +12,7 @@ export class Page {
 
 	async open (appPath, urlExtra = '?locale=en-US') {
 		await browser.execute(function () {
-			document.body.innerHTML = '';
+			document.body.textContent = '';
 		});
 
 		this._url = `/${appPath}/${urlExtra}`;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some dependencies required major version update

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- globals              ^16.x  →  ^17.x
  -  Split audioWorklet environment from browser ==> Not affecting Enact
  (https://github.com/sindresorhus/globals/releases)
- readdirp         ^3.x  →   ^5.x
  - Support hybrid common.js / esm modules
  - **Remove glob support and all dependencies** ==> Changed used filename filter
   - **Increase minimum node.js version to v20.19**. The versions starting from it support loading esm files from cjs
   - **Make sure you're using let {readdirp} = require('readdirp') in common.js** ==> used ReaddirpPromise()
  - This package is now pure ESM
  (https://github.com/paulmillr/readdirp/releases)
- ramda ^0.31..x  →   ^0.32.x
  - no breaking changes
  (https://github.com/ramda/ramda/releases)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Changed node version in travis as node 21 is not supported

Chrome 132 started enforcing Trusted Types, a security feature that prevents XSS (Cross-Site Scripting) attacks by blocking direct assignments to dangerous APIs like innerHTML. ==> replaced setting innerHTMl with textContent. The issue is visible on Windows environment

- query-string         ^7.x  →   ^9.x ==> could not be updated because it surfaces a bug that we have in enact/dev-utils
  - Require Node.js 18
  - This package is now pure ESM
  (https://github.com/sindresorhus/query-string/releases)

### Links
[//]: # (Related issues, references)
NXT-7082

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)