### PR TITLE
NXT-10274: Added logic to not add pending failing ss-tests to failedTests.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 
+* Fixed ss-tests to add entry in failedTests.html only if all retries of a test failed.
 * Updated dependencies versions to the latest.
 * Required Node.js version "^20.19.0 || ^22.0.0 || >=24.0.0"
 

--- a/screenshot/utils/confHelpers.js
+++ b/screenshot/utils/confHelpers.js
@@ -54,6 +54,7 @@ function initFile (name, content) {
 function onPrepare () {
 	global.sessionFailures = new Map();
 	global.failedSessions = new Set();
+	global.pendingFailures = new Map();
 
 	if (!fs.existsSync('tests/screenshot/dist/screenshots/reference')) {
 		console.log('No reference screenshots found, creating new references!');
@@ -263,38 +264,25 @@ async function afterTest (testData, _context, {error, passed}) {
 			});
 		}
 
+		const testIdentifier = testData.title + '::' + fileName;
+
 		if (!passed) {
-			// Track failed tests to avoid duplicate logging during retries
-			if (!global.loggedFailures) {
-				global.loggedFailures = new Set();
+			// Track pending failed tests to avoid duplicate logging during retries
+			if (!global.pendingFailures) {
+				global.pendingFailures = new Map();
 			}
 
-			const testIdentifier = testData.title + '::' + fileName;
-
-			// Only log if we haven't already logged this test failure
-			if (!global.loggedFailures.has(testIdentifier)) {
-				global.loggedFailures.add(testIdentifier);
-
+			if (!global.pendingFailures.has(testIdentifier)) {
 				const screenPath = path.join(screenshotRelativePath, 'actual', fileName);
 				const diffPath = path.join(screenshotRelativePath, 'diff', fileName);
-				fs.open(failedScreenshotFilename, 'a', (err, fd) => {
-					if (err) {
-						console.error('Unable to create failed test log file!');
-					} else {
-						const title = testData.title.replace(/~\//g, '/');
-						const {params, url} = testData.context;
-						const output = {title, diffPath, referencePath, screenPath, params, url};
-						fs.appendFile(fd, `${JSON.stringify(output)},`, 'utf8', () => {
-							fs.close(fd);
-						});
-					}
-				});
+				const title = testData.title.replace(/~\//g, '/');
+				const {params, url} = testData.context;
+				global.pendingFailures.set(testIdentifier, {title, diffPath, referencePath, screenPath, params, url});
 			}
 		} else {
-			// Test passed on retry - remove from logged failures
-			if (global.loggedFailures) { // eslint-disable-line no-lonely-if
-				const testIdentifier = testData.title + '::' + fileName;
-				global.loggedFailures.delete(testIdentifier);
+			// Test passed (possibly on retry) — remove from pending so it won't be reported as failed
+			if (global.pendingFailures) { // eslint-disable-line no-lonely-if
+				global.pendingFailures.delete(testIdentifier);
 			}
 		}
 	}
@@ -303,6 +291,13 @@ async function afterTest (testData, _context, {error, passed}) {
 }
 
 function onComplete () {
+	// Write all tests that ultimately failed
+	if (global.pendingFailures && global.pendingFailures.size > 0) {
+		for (const output of global.pendingFailures.values()) {
+			fs.appendFileSync(failedScreenshotFilename, `${JSON.stringify(output)},`, 'utf8');
+		}
+	}
+
 	const {size: newSize} = fs.statSync(newScreenshotFilename),
 		{size: failedSize} = fs.statSync(failedScreenshotFilename);
 

--- a/screenshot/utils/confHelpers.js
+++ b/screenshot/utils/confHelpers.js
@@ -32,10 +32,7 @@ const baselineRelativePath = 'screenshots/reference';
 const screenshotRelativePath = 'screenshots/screen';
 const baselineFolder = path.join(distPath, baselineRelativePath);
 const screenshotFolder = path.join(distPath, screenshotRelativePath);
-
-// afterTest (worker) writes a file on failure and deletes it on pass.
-// onComplete (main process) reads whatever survived and flushes them to failedTests.html.
-const pendingFailuresDir = path.join(distPath, 'pending-failures');
+const pendingFailuresFolder = path.join(distPath, 'pending-failures');
 
 const generateReferenceName = getScreenshotName(baselineFolder);
 
@@ -60,10 +57,10 @@ function onPrepare () {
 	global.failedSessions = new Set();
 
 	// Clear any leftover pending-failure files from a previous run
-	if (fs.existsSync(pendingFailuresDir)) {
-		fs.rmSync(pendingFailuresDir, {recursive: true, force: true});
+	if (fs.existsSync(pendingFailuresFolder)) {
+		fs.rmSync(pendingFailuresFolder, {recursive: true, force: true});
 	}
-	fs.mkdirSync(pendingFailuresDir, {recursive: true});
+	fs.mkdirSync(pendingFailuresFolder, {recursive: true});
 
 	if (!fs.existsSync('tests/screenshot/dist/screenshots/reference')) {
 		console.log('No reference screenshots found, creating new references!');
@@ -277,7 +274,7 @@ async function afterTest (testData, _context, {error, passed}) {
 		// delete the right file on a passing retry, even across different worker processes.
 		const testIdentifier = testData.title + '::' + fileName;
 		const pendingKey = cryptoModule.createHash('md5').update(testIdentifier).digest('hex');
-		const pendingFile = path.join(pendingFailuresDir, `${pendingKey}.json`);
+		const pendingFile = path.join(pendingFailuresFolder, `${pendingKey}.json`);
 
 		if (!passed) {
 			// Track pending failed tests to avoid duplicate logging during retries
@@ -306,17 +303,17 @@ async function afterTest (testData, _context, {error, passed}) {
 
 function onComplete () {
 	// Write all tests that ultimately failed
-	if (fs.existsSync(pendingFailuresDir)) {
-		const pendingFiles = fs.readdirSync(pendingFailuresDir).filter(f => f.endsWith('.json'));
+	if (fs.existsSync(pendingFailuresFolder)) {
+		const pendingFiles = fs.readdirSync(pendingFailuresFolder).filter(f => f.endsWith('.json'));
 		for (const file of pendingFiles) {
 			try {
-				const raw = fs.readFileSync(path.join(pendingFailuresDir, file), 'utf8');
+				const raw = fs.readFileSync(path.join(pendingFailuresFolder, file), 'utf8');
 				fs.appendFileSync(failedScreenshotFilename, `${raw},`, 'utf8');
 			} catch (e) {
 				console.error(`Failed to flush pending failure ${file}: ${e.message}`);
 			}
 		}
-		fs.rmSync(pendingFailuresDir, {recursive: true, force: true});
+		fs.rmSync(pendingFailuresFolder, {recursive: true, force: true});
 	}
 
 	const {size: newSize} = fs.statSync(newScreenshotFilename),

--- a/screenshot/utils/confHelpers.js
+++ b/screenshot/utils/confHelpers.js
@@ -306,6 +306,7 @@ async function afterTest (testData, _context, {error, passed}) {
 
 function onComplete () {
 	// Write all tests that ultimately failed
+	if (fs.existsSync(pendingFailuresDir)) {
 		const pendingFiles = fs.readdirSync(pendingFailuresDir).filter(f => f.endsWith('.json'));
 		for (const file of pendingFiles) {
 			try {

--- a/screenshot/utils/confHelpers.js
+++ b/screenshot/utils/confHelpers.js
@@ -33,6 +33,10 @@ const screenshotRelativePath = 'screenshots/screen';
 const baselineFolder = path.join(distPath, baselineRelativePath);
 const screenshotFolder = path.join(distPath, screenshotRelativePath);
 
+// afterTest (worker) writes a file on failure and deletes it on pass.
+// onComplete (main process) reads whatever survived and flushes them to failedTests.html.
+const pendingFailuresDir = path.join(distPath, 'pending-failures');
+
 const generateReferenceName = getScreenshotName(baselineFolder);
 
 function initFile (name, content) {
@@ -54,7 +58,12 @@ function initFile (name, content) {
 function onPrepare () {
 	global.sessionFailures = new Map();
 	global.failedSessions = new Set();
-	global.pendingFailures = new Map();
+
+	// Clear any leftover pending-failure files from a previous run
+	if (fs.existsSync(pendingFailuresDir)) {
+		fs.rmSync(pendingFailuresDir, {recursive: true, force: true});
+	}
+	fs.mkdirSync(pendingFailuresDir, {recursive: true});
 
 	if (!fs.existsSync('tests/screenshot/dist/screenshots/reference')) {
 		console.log('No reference screenshots found, creating new references!');
@@ -264,25 +273,30 @@ async function afterTest (testData, _context, {error, passed}) {
 			});
 		}
 
+		// Use a stable filename derived from the test identifier so the worker can find and
+		// delete the right file on a passing retry, even across different worker processes.
 		const testIdentifier = testData.title + '::' + fileName;
+		const pendingKey = cryptoModule.createHash('md5').update(testIdentifier).digest('hex');
+		const pendingFile = path.join(pendingFailuresDir, `${pendingKey}.json`);
 
 		if (!passed) {
 			// Track pending failed tests to avoid duplicate logging during retries
-			if (!global.pendingFailures) {
-				global.pendingFailures = new Map();
-			}
-
-			if (!global.pendingFailures.has(testIdentifier)) {
-				const screenPath = path.join(screenshotRelativePath, 'actual', fileName);
-				const diffPath = path.join(screenshotRelativePath, 'diff', fileName);
-				const title = testData.title.replace(/~\//g, '/');
-				const {params, url} = testData.context;
-				global.pendingFailures.set(testIdentifier, {title, diffPath, referencePath, screenPath, params, url});
+			const screenPath = path.join(screenshotRelativePath, 'actual', fileName);
+			const diffPath = path.join(screenshotRelativePath, 'diff', fileName);
+			const title = testData.title.replace(/~\//g, '/');
+			const {params, url} = testData.context;
+			const output = {title, diffPath, referencePath, screenPath, params, url};
+			try {
+				fs.writeFileSync(pendingFile, JSON.stringify(output), 'utf8');
+			} catch (writeErr) {
+				console.error(`Unable to stage failure for "${title}": ${writeErr.message}`);
 			}
 		} else {
-			// Test passed (possibly on retry) — remove from pending so it won't be reported as failed
-			if (global.pendingFailures) { // eslint-disable-line no-lonely-if
-				global.pendingFailures.delete(testIdentifier);
+			// Test passed (possibly on retry) — remove the staged failure so it won't be reported
+			try {
+				fs.unlinkSync(pendingFile);
+			} catch (e) {
+				// test passed on first attempt — nothing to do
 			}
 		}
 	}
@@ -292,10 +306,16 @@ async function afterTest (testData, _context, {error, passed}) {
 
 function onComplete () {
 	// Write all tests that ultimately failed
-	if (global.pendingFailures && global.pendingFailures.size > 0) {
-		for (const output of global.pendingFailures.values()) {
-			fs.appendFileSync(failedScreenshotFilename, `${JSON.stringify(output)},`, 'utf8');
+		const pendingFiles = fs.readdirSync(pendingFailuresDir).filter(f => f.endsWith('.json'));
+		for (const file of pendingFiles) {
+			try {
+				const raw = fs.readFileSync(path.join(pendingFailuresDir, file), 'utf8');
+				fs.appendFileSync(failedScreenshotFilename, `${raw},`, 'utf8');
+			} catch (e) {
+				console.error(`Failed to flush pending failure ${file}: ${e.message}`);
+			}
 		}
+		fs.rmSync(pendingFailuresDir, {recursive: true, force: true});
 	}
 
 	const {size: newSize} = fs.statSync(newScreenshotFilename),


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Jenkins job for screenshot tests shows 1 failed tests, but also 2 other tests that passed after a retry. 
FailedTests.html shows 3 entries, 2 of them having a broken "diff". But there are no diffs on the server because those 2 tests passed.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The solution is to track pending failed tests and to log the entry to  `failedScreenshotFilename` only if all retries have failed. The entry will be added only at the completion of the tests

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
pendingKey was added to overcome possible invalid filename characters and path length limits

### Links
[//]: # (Related issues, references)
NXT-10274

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)