### PR TITLE
NXT-14655 [POC] investigate screenshot tests using Playwright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [unreleased]
+
+* Added `--parallel` CLI option for WDIO configs to set `maxInstances` without changing `testId % --instances` sharding in `runTest.js`
+* Added package export `@enact/ui-test-utils/build-apps` for programmatic screenshot/UI app builds
+* Changed Docker screenshot config to derive Selenium `NODE_MAX_SESSION` from `--parallel` (fallback `--instances`)
+
 ## [4.0.2] (April 7, 2026)
 
 * Fixed ss-tests to add entry in failedTests.html only if all retries of a test failed.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ To limit or increase the number of concurrent tests, use the `--instances` optio
 npm run test-ui -- --instances 2
 ```
 
+To run more tests in parallel **without** changing CI sharding (`testId % instances`), use `--parallel` (concurrent browsers only). Sharding still uses `--instances`:
+
+```bash
+npm run test-ss -- --component Chip --spec Default-specs --instances 1 --parallel 5
+```
+
 ### Running Tests Offline
 
 By default, the latest versions of various drivers will be downloaded before starting tests. This

--- a/config/wdio.conf.js
+++ b/config/wdio.conf.js
@@ -3,7 +3,7 @@ import parseArgs from 'minimist';
 const args = parseArgs(process.argv);
 
 const visibleBrowser = !!args.visible,
-	maxInstances = args.instances || 5;
+	maxInstances = args.parallel || args.instances || 5;
 
 export const configure = (options) => {
 	const {base, services} = options;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "./ui/wdio.conf.js": "./ui/wdio.conf.js",
     "./ui/wdio.docker.conf.js": "./ui/wdio.docker.conf.js",
     "./ui/wdio.tv.conf.js": "./ui/wdio.tv.conf.js",
-    "./utils": "./utils/index.js"
+    "./utils": "./utils/index.js",
+    "./build-apps": "./src/build-apps.js"
   },
   "bin": {
     "start-tests": "./start-tests.js"

--- a/screenshot/wdio.docker.conf.js
+++ b/screenshot/wdio.docker.conf.js
@@ -1,5 +1,10 @@
+import parseArgs from 'minimist';
+
 import {ipAddress} from '../utils/ipAddress.js';
 import {config as ssConfig} from './wdio.conf.js';
+
+const args = parseArgs(process.argv);
+const maxSessions = args.parallel || args.instances || 5;
 
 // Remove selenium-standalone and replace with docker service
 const services = ssConfig.services
@@ -16,9 +21,12 @@ const config = Object.assign(
 			image: 'selenium/standalone-chrome',
 			healthCheck: 'http://localhost:4444',
 			options: {
-				e: ['NODE_MAX_INSTANCE=5', 'NODE_MAX_SESSION=5'],
+				e: [
+					`NODE_MAX_INSTANCE=${maxSessions}`,
+					`NODE_MAX_SESSION=${maxSessions}`
+				],
 				p: ['4444:4444'],
-				shmSize: '2g'
+				shmSize: maxSessions > 5 ? '3g' : '2g'
 			}
 		}
 	}

--- a/utils/runTest.js
+++ b/utils/runTest.js
@@ -6,10 +6,10 @@ const args = parseArgs(process.argv);
 const pattern = args.component, // Component group to match
 	testToExecute = args.id,    // Specific test ID
 	titlePattern = args.title,  // Pattern for matching test case title
-	maxInstances = args.instances || 5;  // concurrent instances for 'manual' concurrency
+	shardCount = args.instances || 5;  // testId % shardCount (CI sharding)
 
 export const runTest = ({concurrency, filter, Page, testName, ...rest}) => {
-	if (concurrency && (concurrency > maxInstances)) {
+	if (concurrency && (concurrency > shardCount)) {
 		return;
 	}
 
@@ -34,7 +34,7 @@ export const runTest = ({concurrency, filter, Page, testName, ...rest}) => {
 
 					describe(component, function () {
 						testCases[component].forEach((testCase, testId) => {
-							if (concurrency && testId % maxInstances !== concurrency - 1) {
+							if (concurrency && testId % shardCount !== concurrency - 1) {
 								return;
 							}
 							if (testToExecute >= 0 && testToExecute !== testId) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
NXT-14655 — Support decoupled WDIO sharding (--instances) from browser parallelism (--parallel), and expose build-apps as a stable package export for Playwright screenshot setup in Limestone.

Previously --instances controlled both testId % N sharding and wdio:maxInstances, so running all cases for one component with multiple browsers required awkward workarounds.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- --parallel CLI — config/wdio.conf.js sets maxInstances from args.parallel || args.instances || 5. Sharding in utils/runTest.js still uses only args.instances (renamed internally to shardCount for clarity).
- Docker screenshot config — screenshot/wdio.docker.conf.js passes NODE_MAX_INSTANCE / NODE_MAX_SESSION from --parallel (fallback --instances), and bumps shmSize when maxSessions > 5.
- ./build-apps export — package.json exports @enact/ui-test-utils/build-apps so consumers (e.g. Playwright global-setup) can import buildApps without reaching into node_modules/.../src/.
- README — documents --instances 1 --parallel 5 for component-level parallel runs.

- **`2g` (default, `maxSessions ≤ 5`)** — Same as the long-standing WDIO Docker config. Chrome in Docker needs far more than Docker’s default `/dev/shm` (~64MB); Selenium’s guidance is to use ~2GB to avoid renderer crashes during visual tests.
- **`3g` (`maxSessions > 5`)** — Added with `--parallel` support so `NODE_MAX_SESSION` can exceed the previous fixed cap of 5. When more Chrome instances run concurrently in one container, they compete for `/dev/shm`. We keep `2g` for the existing ≤5-worker path and bump to `3g` only when parallelism goes higher, as a conservative +1GB headroom to reduce Docker Chrome instability. This is a pragmatic threshold, not a per-session formula derived from profiling.
`maxSessions` is taken from `--parallel`, then `--instances`, then defaults to `5`.

Impact: Backward compatible. Existing CI using only --instances behaves as before. New --parallel enables fair Playwright vs WDIO benchmarks and faster single-component runs without changing shard math.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-14655

### Comments
Enact-DCO-1.0-Signed-off-by: Dan Ichim ([dan.ichim@lgepartner.com](mailto:dan.ichim@lgepartner.com))