### PR TITLE
NXT-16296: Improved layout for `failedTests.html` for screenshot tests

### DIFF
--- a/screenshot/TestChooser.module.css
+++ b/screenshot/TestChooser.module.css
@@ -8,7 +8,7 @@
 	margin-left: 64px;
 	margin-right: 64px;
 	padding: 0 24px;
-	border: 0px solid transparent;
+	border: 0 solid transparent;
 	border-bottom: 6px solid #ccc;
 	border-radius: 0.3em;
 }

--- a/screenshot/utils/headerTemplate.js
+++ b/screenshot/utils/headerTemplate.js
@@ -10,12 +10,14 @@ export function makeHeader (title) {
 		</header>
 		<div class="cell body">
 			<div class="row">
-				<div class="cell fixed list">
+				<div class="cell fixed list" id="drawer">
 					<ol></ol>
 				</div>
+				<div id="overlay"></div>
 				<div class="cell preview">
 					<div class="column">
 						<div class="cell fixed preview-header">
+							<button id="menu">&#9776;</button> 
 							<button id="dec">&lt;</button>
 							<button id="inc">&gt;</button>
 							<div id="title">Select an image</div>

--- a/screenshot/utils/headerTemplate.js
+++ b/screenshot/utils/headerTemplate.js
@@ -13,7 +13,6 @@ export function makeHeader (title) {
 				<div class="cell fixed list" id="drawer">
 					<ol></ol>
 				</div>
-				<div id="overlay"></div>
 				<div class="cell preview">
 					<div class="column">
 						<div class="cell fixed preview-header">

--- a/screenshot/utils/headerTemplate.js
+++ b/screenshot/utils/headerTemplate.js
@@ -10,7 +10,7 @@ export function makeHeader (title) {
 		</header>
 		<div class="cell body">
 			<div class="row">
-				<div class="cell fixed list" id="drawer">
+				<div class="cell fixed list">
 					<ol></ol>
 				</div>
 				<div class="cell preview">

--- a/screenshot/utils/redist/failedTests.js
+++ b/screenshot/utils/redist/failedTests.js
@@ -58,8 +58,13 @@
 		return btn;
 	}
 
-	function toggleDrawer (collapsed) {
-		drawer.classList.toggle('collapsed', collapsed);
+	function toggleDrawer ({collapsed}) {
+		if (collapsed) {
+			return drawer.classList.toggle('collapsed', collapsed);
+		}
+
+		const currentState = !drawer.classList.contains('collapsed');
+		drawer.classList.toggle('collapsed', currentState);
 	}
 
 	function initializeButtons () {
@@ -93,7 +98,7 @@
 
 		inc.onclick = nextImage;
 		dec.onclick = prevImage;
-		menu.onclick = () => toggleDrawer(!drawer.classList.contains('collapsed'));
+		menu.onclick = toggleDrawer;
 	}
 
 	function updateButtons (type) {
@@ -118,7 +123,7 @@
 	document.onkeydown = (ev) => {
 		switch (ev.key) {
 			case "Escape":
-				toggleDrawer(true);
+				toggleDrawer({collapsed: true});
 				break;
 			case "ArrowLeft":
 				if (count > 0 && currentIndex > 0) {

--- a/screenshot/utils/redist/failedTests.js
+++ b/screenshot/utils/redist/failedTests.js
@@ -2,7 +2,6 @@
 	const h = document.querySelector('h1');
 	const list = document.querySelector('.list > ol');
 	const drawer = document.querySelector('.list');
-	const overlay = document.querySelector('#overlay');
 	const count = results.length;
 	let currentIndex = -1;
 
@@ -59,9 +58,8 @@
 		return btn;
 	}
 
-	function toggleDrawer (open) {
-		drawer.classList.toggle('open', open);
-		overlay.classList.toggle('visible', open);
+	function toggleDrawer (closed) {
+		drawer.classList.toggle('closed', closed);
 	}
 
 	function initializeButtons () {
@@ -95,8 +93,7 @@
 
 		inc.onclick = nextImage;
 		dec.onclick = prevImage;
-		menu.onclick = () => toggleDrawer(!drawer.classList.contains('open'));
-		overlay.onclick = () => toggleDrawer(false);
+		menu.onclick = () => toggleDrawer(!drawer.classList.contains('closed'));
 	}
 
 	function updateButtons (type) {
@@ -121,7 +118,7 @@
 	document.onkeydown = (ev) => {
 		switch (ev.key) {
 			case "Escape":
-				toggleDrawer(false);
+				toggleDrawer(true);
 				break;
 			case "ArrowLeft":
 				if (count > 0 && currentIndex > 0) {

--- a/screenshot/utils/redist/failedTests.js
+++ b/screenshot/utils/redist/failedTests.js
@@ -58,8 +58,8 @@
 		return btn;
 	}
 
-	function toggleDrawer (closed) {
-		drawer.classList.toggle('closed', closed);
+	function toggleDrawer (collapsed) {
+		drawer.classList.toggle('collapsed', collapsed);
 	}
 
 	function initializeButtons () {
@@ -93,7 +93,7 @@
 
 		inc.onclick = nextImage;
 		dec.onclick = prevImage;
-		menu.onclick = () => toggleDrawer(!drawer.classList.contains('closed'));
+		menu.onclick = () => toggleDrawer(!drawer.classList.contains('collapsed'));
 	}
 
 	function updateButtons (type) {

--- a/screenshot/utils/redist/failedTests.js
+++ b/screenshot/utils/redist/failedTests.js
@@ -1,6 +1,8 @@
 ((results) => {
 	const h = document.querySelector('h1');
 	const list = document.querySelector('.list > ol');
+	const drawer = document.querySelector('.list');
+	const overlay = document.querySelector('#overlay');
 	const count = results.length;
 	let currentIndex = -1;
 
@@ -56,9 +58,16 @@
 		target.appendChild(btn);
 		return btn;
 	}
+
+	function toggleDrawer (open) {
+		drawer.classList.toggle('open', open);
+		overlay.classList.toggle('visible', open);
+	}
+
 	function initializeButtons () {
 		const inc = document.querySelector('#inc'),
-			dec = document.querySelector('#dec');
+			dec = document.querySelector('#dec'),
+			menu = document.querySelector('#menu');
 		let nextTarget = inc;
 
 		const buttonbox = document.createElement('span');
@@ -86,6 +95,8 @@
 
 		inc.onclick = nextImage;
 		dec.onclick = prevImage;
+		menu.onclick = () => toggleDrawer(!drawer.classList.contains('open'));
+		overlay.onclick = () => toggleDrawer(false);
 	}
 
 	function updateButtons (type) {
@@ -108,13 +119,16 @@
 	}
 
 	document.onkeydown = (ev) => {
-		switch (ev.keyCode) {
-			case 37:
+		switch (ev.key) {
+			case "Escape":
+				toggleDrawer(false);
+				break;
+			case "ArrowLeft":
 				if (count > 0 && currentIndex > 0) {
 					prevImage();
 				}
 				break;
-			case 39:
+			case "ArrowRight":
 				if (count > 0 && currentIndex < (count - 1)) {
 					nextImage();
 				}

--- a/screenshot/utils/redist/styles.css
+++ b/screenshot/utils/redist/styles.css
@@ -54,22 +54,13 @@ ol li {
 }
 
 .list {
-	background: #fff;
-	bottom: 0;
-	box-shadow: 2px 0 12px rgba(0,0,0,0.25);
-	left: 0;
-	max-width: 40%;
-	overflow-y: auto;
-	padding-top: 8px;
-	position: fixed;
-	top: 0;
-	transform: translateX(-100%);
-	transition: transform 0.25s ease;
-	width: 360px;
-	z-index: 100;
+	margin-right: 12px;
+	max-width: 25%;
+	overflow: auto;
+	transition: transform 0.2s ease;
 }
-.list.open {
-	transform: translateX(0);
+.list.closed {
+	max-width: 0;
 }
 
 .list ol {
@@ -163,21 +154,11 @@ button.active {
 
 #image {
 	cursor: zoom-in;
+	width: 100%;
 }
 #image:focus {
 	transform: scale(4);
 	transform-origin: top left;
 	cursor: crosshair;
 	image-rendering: pixelated;
-}
-
-#overlay {
-	display: none;
-	position: fixed;
-	inset: 0;
-	background: rgba(0,0,0,0.3);
-	z-index: 99;
-}
-#overlay.visible {
-	display: block;
 }

--- a/screenshot/utils/redist/styles.css
+++ b/screenshot/utils/redist/styles.css
@@ -60,7 +60,7 @@ ol li {
 	overflow: auto;
 	transition: transform 0.2s ease;
 }
-.list.closed {
+.list.collapsed {
 	max-width: 0;
 }
 

--- a/screenshot/utils/redist/styles.css
+++ b/screenshot/utils/redist/styles.css
@@ -42,7 +42,8 @@ ol li {
 }
 
 .cell {
-	flex: 1 1 100%;
+	flex: 1 1 0;
+	min-height: 0;
 	position: relative;
 }
 .cell.fixed {

--- a/screenshot/utils/redist/styles.css
+++ b/screenshot/utils/redist/styles.css
@@ -58,7 +58,6 @@ ol li {
 	margin-right: 12px;
 	max-width: 25%;
 	overflow: auto;
-	transition: transform 0.2s ease;
 }
 .list.collapsed {
 	max-width: 0;

--- a/screenshot/utils/redist/styles.css
+++ b/screenshot/utils/redist/styles.css
@@ -54,10 +54,24 @@ ol li {
 }
 
 .list {
-	margin-right: 12px;
-	overflow: auto;
+	background: #fff;
+	bottom: 0;
+	box-shadow: 2px 0 12px rgba(0,0,0,0.25);
+	left: 0;
 	max-width: 40%;
+	overflow-y: auto;
+	padding-top: 8px;
+	position: fixed;
+	top: 0;
+	transform: translateX(-100%);
+	transition: transform 0.25s ease;
+	width: 360px;
+	z-index: 100;
 }
+.list.open {
+	transform: translateX(0);
+}
+
 .list ol {
 	margin-top: 0;
 }
@@ -155,4 +169,15 @@ button.active {
 	transform-origin: top left;
 	cursor: crosshair;
 	image-rendering: pixelated;
+}
+
+#overlay {
+	display: none;
+	position: fixed;
+	inset: 0;
+	background: rgba(0,0,0,0.3);
+	z-index: 99;
+}
+#overlay.visible {
+	display: block;
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Improved layout for `failedTests.html` for screenshot tests

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Reduced the size of the failed tests list
- Added a button that allows you to hide the failed tests list
- Set the width of 100% for the failed screenshot image

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Remove the test branch from limestone after the merge [Limestone branch](https://github.com/enactjs/limestone/tree/feature/NXT-15181)

### Links
[//]: # (Related issues, references)
NXT-15181

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com