### PR TITLE
NXT-17613: Fixed screenshot tests to determine title based also on `focus` and `portrait1 props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [4.0.4] (July 7, 2026)
 
+* Fixed screenshot tests to determine title based also on `focus` and `portrait` props.
+
+## [4.0.4] (July 7, 2026)
+
 * Added support for `portrait` orientation
 
 ## [4.0.3] (June 23, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [4.0.4] (July 7, 2026)
+## [unreleased]
 
 * Fixed screenshot tests to determine title based also on `focus` and `portrait` props.
 

--- a/utils/generateTestData.js
+++ b/utils/generateTestData.js
@@ -90,6 +90,8 @@ export const generateTestData = (component, componentTests) => {
 			title = stringifyProps({
 				skin: testCase.skin,
 				locale: testCase.locale,
+				focus: testCase.focus,
+				portrait: testCase.portrait,
 				props: testCase.props ? testCase.props : testCase.component.props,
 				wrapper: testCase.wrapper,
 				textSize: testCase.textSize,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed screenshot tests to determine title based also on `focus` and `portrait` props

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-17613

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)