### PR TITLE
NXT-17615: Fixed screenshot tests failedTest.html to populate all failed entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [unreleased]
+
+* Fixed ss-tests to correctly log failing tests to failedTests.html
+
 ## [4.0.4] (July 7, 2026)
 
 * Added support for `portrait` orientation

--- a/screenshot/utils/confHelpers.js
+++ b/screenshot/utils/confHelpers.js
@@ -258,9 +258,13 @@ async function beforeTest (testData) {
 }
 
 async function afterTest (testData, _context, {error, passed}) {
+	// WDIO v9 passes `testData` as an identity snapshot captured *before* the test body runs,
+	// so the `context` assigned inside the test (`this.test.context = context`) is not present on it.
+	const testContext = (_context && _context.test && _context.test.context) || testData.context;
+
 	// If this doesn't include context data, not a screenshot test
-	if (testData && testData.title && testData.context && testData.context.params) {
-		const fileName = testData.context.fileName.replace(/ /g, '_') + '.png';
+	if (testData && testData.title && testContext && testContext.params) {
+		const fileName = testContext.fileName.replace(/ /g, '_') + '.png';
 		const referencePath = path.join(baselineRelativePath, fileName);
 
 		if (_context.isNewScreenshot) {
@@ -268,7 +272,7 @@ async function afterTest (testData, _context, {error, passed}) {
 				if (err) {
 					console.error('Unable to create log file!');
 				} else {
-					const {params, url} = testData.context;
+					const {params, url} = testContext;
 					const output = {title: testData.title.replace(/~\//g, '/'), path: referencePath, params, url};
 					fs.appendFile(fd, `${JSON.stringify(output)},`, 'utf8', () => {
 						fs.close(fd);
@@ -288,7 +292,7 @@ async function afterTest (testData, _context, {error, passed}) {
 			const screenPath = path.join(screenshotRelativePath, 'actual', fileName);
 			const diffPath = path.join(screenshotRelativePath, 'diff', fileName);
 			const title = testData.title.replace(/~\//g, '/');
-			const {params, url} = testData.context;
+			const {params, url} = testContext;
 			const output = {title, diffPath, referencePath, screenPath, params, url};
 			try {
 				fs.writeFileSync(pendingFile, JSON.stringify(output), 'utf8');

--- a/screenshot/utils/confHelpers.js
+++ b/screenshot/utils/confHelpers.js
@@ -258,8 +258,8 @@ async function beforeTest (testData) {
 }
 
 async function afterTest (testData, _context, {error, passed}) {
-	// WDIO v9 passes `testData` as an identity snapshot captured *before* the test body runs,
-	// so the `context` assigned inside the test (`this.test.context = context`) is not present on it.
+	// WDIO v9 passes `testData` as an identity snapshot captured before the test body runs,
+	// so the `context` assigned inside the test is not present on it.
 	const testContext = (_context && _context.test && _context.test.context) || testData.context;
 
 	// If this doesn't include context data, not a screenshot test


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed screenshot tests failedTest.html to populate all failed entries

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-17615

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)